### PR TITLE
更新了少量功能

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -325,8 +325,13 @@ const fetchRepoData = async () => {
       repoInfo = await response.json();
     } */
 
-    if (selectedRepo.value === 'local') { // 根据选择的仓库判断
-      repoInfo = await GetRepoDataFromLocal();
+    if (mode === 'single') {
+      if (selectedRepo.value === 'local') { // 根据选择的仓库判断
+        repoInfo = await GetRepoDataFromLocal();
+      } else {
+        const response = await fetch(selectedRepo.value);
+        repoInfo = await response.json();
+      }
     } else {
       const response = await fetch(selectedRepo.value);
       repoInfo = await response.json();
@@ -500,18 +505,32 @@ const downloadScript = async (script) => {
     });
   } */
 
-  if (selectedRepo.value === 'local') {
-    try {
-      await subscribeToLocal(fullUrl);
-    } catch (error) {
-      console.error('订阅失败:', error);
-      Message.error(`订阅失败: ${error.message}`);
+  if (mode === 'single') {
+    if (selectedRepo.value === 'local') {
+      try {
+        await subscribeToLocal(fullUrl);
+      } catch (error) {
+        console.error('订阅失败:', error);
+        Message.error(`订阅失败: ${error.message}`);
+      }
+    } else {
+      copy(fullUrl).then(() => {
+        Message.success(`订阅链接已复制，回到地图追踪页面以继续导入`);
+      }).catch((error) => {
+        console.error('复制到剪贴板失败:', error);
+        Message.error(`复制 ${script.name} 的订阅链接失败`);
+      });
     }
   } else {
+    // 将完整的 URL 复制到剪贴板
     copy(fullUrl).then(() => {
-      Message.success(`订阅链接已复制，回到地图追踪页面以继续导入`);
+      Message.success(`已将 ${script.name} 的订阅链接复制到剪贴板`);
+    }).catch((error) => {
+      console.error('复制到剪贴板失败:', error);
+      Message.error(`复制 ${script.name} 的订阅链接失败`);
     });
   }
+  
 };
 
 const subscribeToLocal = async (url) => {

--- a/src/App.vue
+++ b/src/App.vue
@@ -186,18 +186,17 @@ const handleTreeSearch = () => {
 // 添加树节点过滤函数
 const filterTreeNodes = (nodes, searchText) => {
   return nodes.map(node => {
+    const isSelfMatch = isPinyinMatch(node.title, searchText);
+    
+    if (isSelfMatch) {
+      return { ...node };
+    }
+
     const newNode = { ...node };
     if (newNode.children) {
       newNode.children = filterTreeNodes(newNode.children, searchText);
     }
-
-    if (
-      isPinyinMatch(newNode.title, searchText) ||
-      (newNode.children && newNode.children.length > 0)
-    ) {
-      return newNode;
-    }
-    return null;
+    return (newNode.children?.length > 0) ? newNode : null;
   }).filter(Boolean);
 };
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -201,7 +201,8 @@ const filterTreeNodes = (nodes, searchText) => {
 };
 
 // 修改 repoOptions 的定义
-const repoOptions = computed(() => {
+
+/* const repoOptions = computed(() => {
   if (mode === 'single') {
     return [{ label: "BetterGI 本地仓库", value: "local" }];
   } else {
@@ -210,6 +211,27 @@ const repoOptions = computed(() => {
       value: url.replace("{0}", baseRepo)
     }));
   }
+}); */
+
+const repoOptions = computed(() => {
+  // 生成镜像选项列表
+  const mirrorOptions = mirrorUrls.map((url, index) => ({
+    label: index === 0 ? "BetterGI 中央仓库" : `镜像源 ${index}`,
+    value: url.replace("{0}", baseRepo)
+  }));
+
+  // 本地模式追加镜像选项
+  if (mode === 'single') {
+    return [
+      { label: "BetterGI 本地仓库", value: "local" },
+      ...mirrorOptions.map(opt => ({
+        ...opt,
+        label: `在线仓库 ${opt.label}` // 添加前缀区分
+      }))
+    ];
+  }
+
+  return mirrorOptions;
 });
 
 const selectedRepo = ref('');
@@ -295,7 +317,15 @@ const fetchRepoData = async () => {
 
   try {
     let repoInfo;
-    if (mode === 'single') {
+    
+    /* if (mode === 'single') {
+      repoInfo = await GetRepoDataFromLocal();
+    } else {
+      const response = await fetch(selectedRepo.value);
+      repoInfo = await response.json();
+    } */
+
+    if (selectedRepo.value === 'local') { // 根据选择的仓库判断
       repoInfo = await GetRepoDataFromLocal();
     } else {
       const response = await fetch(selectedRepo.value);
@@ -328,7 +358,7 @@ const fetchRepoData = async () => {
       });
     });
   } catch (error) {
-    Message.error('获取仓库数据失败');
+    Message.error('获取仓库数据失败，请尝试更换仓库');
     console.error('Error fetching repo data:', error);
   } finally {
     loading.value = false;
@@ -452,7 +482,7 @@ const downloadScript = async (script) => {
   // 创建完整的 URL
   const fullUrl = `bettergi://script?import=${base64String}`;
 
-  if (mode === 'single') {
+  /* if (mode === 'single') {
     try {
       await subscribeToLocal(fullUrl);
       // Message.success(`已成功订阅 ${script.name}`);
@@ -467,6 +497,19 @@ const downloadScript = async (script) => {
     }).catch((error) => {
       console.error('复制到剪贴板失败:', error);
       Message.error(`复制 ${script.name} 的订阅链接失败`);
+    });
+  } */
+
+  if (selectedRepo.value === 'local') {
+    try {
+      await subscribeToLocal(fullUrl);
+    } catch (error) {
+      console.error('订阅失败:', error);
+      Message.error(`订阅失败: ${error.message}`);
+    }
+  } else {
+    copy(fullUrl).then(() => {
+      Message.success(`订阅链接已复制，回到地图追踪页面以继续导入`);
     });
   }
 };
@@ -510,8 +553,8 @@ const getCategoryTree = (category) => {
       selectable: true
     };
 
-    // 只在非本地模式且非根节点时添加图标
-    if (!isRoot && mode !== 'single') {
+    // 添加图标（原本地无法显示图标）
+    if (!isRoot) {
       treeNode.icon = () => h('img', {
         src: getIconUrl(node.name),
         style: {
@@ -641,10 +684,26 @@ onMounted(() => {
   padding: 16px;
 }
 
+:deep(.arco-tree-node) {
+  position: relative;
+  padding-right: 80px !important; /* 给按钮留出空间 */
+}
+
 /* 添加图标相关样式 */
 :deep(.arco-tree-node-title) {
   display: flex;
   align-items: center;
+  width: calc(100% - 60px); /* 留出按钮空间 */
+  min-width: 0; /* 允许文本截断 */
+}
+
+:deep(.arco-tree-node-title-text) {
+  white-space: normal !important;
+  word-break: break-word;
+  line-height: 1.5;
+  max-width: 100%;
+  flex: 1;
+  margin-right: 4px; /* 与按钮间距 */
 }
 
 :deep(.arco-tree-node-icon) {


### PR DESCRIPTION
1.添加了本地仓库下的小图标显示（同在线仓库）
2.优化了标题文字过长的遮挡问题（暂未优化详情页的过长，略略略）
3.bgi内打开脚本仓库可支持选择在线仓库以应对更新超时情况（暂未添加选择默认仓库选项），目前在线仓库可以在本地窗口中打开
4.修改了少量提示信息，增强引导性

注：由于让客户端内支持在线仓库的行为可能出现bug，故老代码仅作注释并未删除